### PR TITLE
Prevent codecov upload failures from failing CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -47,7 +47,6 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
           files: ./tests/coverage.xml
           verbose: true
 


### PR DESCRIPTION
It seems that codecov has issues at times with uploading coveerage.
Since the coverage run is set to fail under 100 we let codecov upload
issues silently fail and continue to let pr's merge
