### PR TITLE
Pin clang to version 6 for rtd

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,7 @@
-# Most requirements are already pulled in through the sphinx dependency of the package.
-# This file just lists the ones that don't get pulled through there.
+# Most requirements are already pulled in through the pyproject.toml
+# This file lists the ones that are extra for generating docs on read the docs
+
+# Use autoprogram for the autodoc CLI
 sphinxcontrib.autoprogram
+# Due to read the docs libclang linking in conf.py we want to use clang 6
+clang == 6


### PR DESCRIPTION
Previously read the docs builds would use the newest clang version. This
was incorrect as the clang version hooked up in `conf.py` was clang
version 6. Now `docs/requirements.txt` requires clang 6.
