### PR TITLE
Remove codecov install from ci

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox codecov
+          pip install tox
           
           # Make libclang available for the parsing of the c files with the python clang package
           sudo ln -s /usr/lib/x86_64-linux-gnu/libclang-14.so.1 /usr/lib/x86_64-linux-gnu/libclang-14.so


### PR DESCRIPTION
Previously the coverage job would install codecov with tox. Now the
coverage package in the tox dependencies are used.
