### PR TITLE
Explicitly specify RTD formats

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,7 @@ sphinx:
   fail_on_warning: false
 
 # Optionally build your docs in additional formats such as PDF and ePub
-formats: all
+formats: html
 
 # Optionally set the version of Python and requirements required to build your
 # docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,10 @@ sphinx:
   fail_on_warning: false
 
 # Optionally build your docs in additional formats such as PDF and ePub
-formats: html
+formats: 
+  - html
+  - pdf
+  - epub
 
 # Optionally set the version of Python and requirements required to build your
 # docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,7 @@ sphinx:
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: 
-  - html
+  - htmlzip
   - pdf
   - epub
 


### PR DESCRIPTION
There is a new RTD format `readthedocssinglehtmllocalmedia` which causes furo to choke.
Limiting formats to `htmlzip`, `pdf`, and `epub` for now.