### PR TITLE
Update sphinx to 7.2.6

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -302,20 +302,6 @@ toml = ["tomli"]
 
 [[package]]
 name = "dill"
-version = "0.3.6"
-description = "serialize all of python"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "dill-0.3.6-py3-none-any.whl", hash = "sha256:a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0"},
-    {file = "dill-0.3.6.tar.gz", hash = "sha256:e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373"},
-]
-
-[package.extras]
-graph = ["objgraph (>=1.7.2)"]
-
-[[package]]
-name = "dill"
 version = "0.3.7"
 description = "serialize all of Python"
 optional = false
@@ -483,16 +469,6 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -686,8 +662,8 @@ astroid = ">=3.0.0,<=3.1.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
     {version = ">=0.2", markers = "python_version < \"3.11\""},
-    {version = ">=0.3.6", markers = "python_version >= \"3.11\""},
     {version = ">=0.3.7", markers = "python_version >= \"3.12\""},
+    {version = ">=0.3.6", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
 ]
 isort = ">=4.2.5,<6"
 mccabe = ">=0.6,<0.8"
@@ -841,6 +817,41 @@ lint = ["docutils-stubs", "flake8 (>=3.5.0)", "flake8-simplify", "isort", "mypy 
 test = ["cython", "filelock", "html5lib", "pytest (>=4.6)"]
 
 [[package]]
+name = "sphinx"
+version = "7.2.6"
+description = "Python documentation generator"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "sphinx-7.2.6-py3-none-any.whl", hash = "sha256:1e09160a40b956dc623c910118fa636da93bd3ca0b9876a7b3df90f07d691560"},
+    {file = "sphinx-7.2.6.tar.gz", hash = "sha256:9a5160e1ea90688d5963ba09a2dcd8bdd526620edbb65c328728f1b2228d5ab5"},
+]
+
+[package.dependencies]
+alabaster = ">=0.7,<0.8"
+babel = ">=2.9"
+colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
+docutils = ">=0.18.1,<0.21"
+imagesize = ">=1.3"
+importlib-metadata = {version = ">=4.8", markers = "python_version < \"3.10\""}
+Jinja2 = ">=3.0"
+packaging = ">=21.0"
+Pygments = ">=2.14"
+requests = ">=2.25.0"
+snowballstemmer = ">=2.0"
+sphinxcontrib-applehelp = "*"
+sphinxcontrib-devhelp = "*"
+sphinxcontrib-htmlhelp = ">=2.0.0"
+sphinxcontrib-jsmath = "*"
+sphinxcontrib-qthelp = "*"
+sphinxcontrib-serializinghtml = ">=1.1.9"
+
+[package.extras]
+docs = ["sphinxcontrib-websupport"]
+lint = ["docutils-stubs", "flake8 (>=3.5.0)", "flake8-simplify", "isort", "mypy (>=0.990)", "ruff", "sphinx-lint", "types-requests"]
+test = ["cython (>=3.0)", "filelock", "html5lib", "pytest (>=4.6)", "setuptools (>=67.0)"]
+
+[[package]]
 name = "sphinx-basic-ng"
 version = "1.0.0b2"
 description = "A modern skeleton for Sphinx themes."
@@ -962,6 +973,24 @@ lint = ["docutils-stubs", "flake8", "mypy"]
 test = ["pytest"]
 
 [[package]]
+name = "sphinxcontrib-serializinghtml"
+version = "1.1.9"
+description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "sphinxcontrib_serializinghtml-1.1.9-py3-none-any.whl", hash = "sha256:9b36e503703ff04f20e9675771df105e58aa029cfcbc23b8ed716019b7416ae1"},
+    {file = "sphinxcontrib_serializinghtml-1.1.9.tar.gz", hash = "sha256:0c64ff898339e1fac29abd2bf5f11078f3ec413cfe9c046d3120d7ca65530b54"},
+]
+
+[package.dependencies]
+Sphinx = ">=5"
+
+[package.extras]
+lint = ["docutils-stubs", "flake8", "mypy"]
+test = ["pytest"]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -1040,4 +1069,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "0c02519faf7945c1260e89b2779c9f7454fed086c02c2a90e39e566cc2a19261"
+content-hash = "6f43694f9d2e9c44c801f463c73254a90655e6210640740094b5577c6f5d7fe1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,10 @@ beautifulsoup4 = "*"
 sphinx-c-apidoc = 'sphinx_c_autodoc.apidoc:main'
 
 [tool.poetry.group.dev.dependencies]
+sphinx = [
+    {version = ">=3.1,<7.2", python = "<3.9"},
+    {version = ">=7.2", python = ">=3.9"}
+]
 black = "23.9.1"
 pycodestyle = "2.11.0"
 mypy =  "1.5.1"

--- a/src/sphinx_c_autodoc/__init__.py
+++ b/src/sphinx_c_autodoc/__init__.py
@@ -153,7 +153,8 @@ class CObjectDocumenter(Documenter):
 
         # The implementation of self.resolve_name() always returns back a str,
         # but typing wise it says optional to be nsync with the Sphinx definition.
-        self.modname, self.objpath = self.resolve_name(fullname, parents, path, base)  # type: ignore
+        self.modname, self.objpath = \
+            self.resolve_name(fullname, parents, path, base)  # type: ignore
 
         self.fullname = self.modname
         return True

--- a/src/sphinx_c_autodoc/__init__.py
+++ b/src/sphinx_c_autodoc/__init__.py
@@ -153,8 +153,9 @@ class CObjectDocumenter(Documenter):
 
         # The implementation of self.resolve_name() always returns back a str,
         # but typing wise it says optional to be nsync with the Sphinx definition.
-        self.modname, self.objpath = \
-            self.resolve_name(fullname, parents, path, base)  # type: ignore
+        self.modname, self.objpath = self.resolve_name(
+            fullname, parents, path, base
+        )  # type: ignore
 
         self.fullname = self.modname
         return True

--- a/src/sphinx_c_autodoc/__init__.py
+++ b/src/sphinx_c_autodoc/__init__.py
@@ -153,9 +153,9 @@ class CObjectDocumenter(Documenter):
 
         # The implementation of self.resolve_name() always returns back a str,
         # but typing wise it says optional to be nsync with the Sphinx definition.
-        self.modname, self.objpath = self.resolve_name(
+        self.modname, self.objpath = self.resolve_name(  # type: ignore
             fullname, parents, path, base
-        )  # type: ignore
+        )
 
         self.fullname = self.modname
         return True

--- a/src/sphinx_c_autodoc/__init__.py
+++ b/src/sphinx_c_autodoc/__init__.py
@@ -151,14 +151,16 @@ class CObjectDocumenter(Documenter):
         else:
             parents = path.rstrip(".").split(".")
 
-        self.modname, self.objpath = self.resolve_name(fullname, parents, path, base)
+        # The implementation of self.resolve_name() always returns back a str,
+        # but typing wise it says optional to be nsync with the Sphinx definition.
+        self.modname, self.objpath = self.resolve_name(fullname, parents, path, base)  # type: ignore
 
         self.fullname = self.modname
         return True
 
     def resolve_name(
-        self, modname: str, parents: List[str], path: Optional[str], base: str
-    ) -> Tuple[str, List[str]]:
+        self, modname: Optional[str], parents: List[str], path: Optional[str], base: str
+    ) -> Tuple[Optional[str], List[str]]:
         """
         Resolve the module and object name of the object to document.
         This can be derived in two ways:
@@ -297,7 +299,7 @@ class CObjectDocumenter(Documenter):
         tab_width = self.directive.state.document.settings.tab_width
         return [prepare_docstring(docstring, tabsize=tab_width)]
 
-    def get_object_members(self, want_all: bool) -> Tuple[bool, List[Tuple[str, Any]]]:
+    def get_object_members(self, want_all: bool) -> Tuple[bool, List[Any]]:
         """Return `(members_check_module, members)` where `members` is a
         list of `(membername, member)` pairs of the members of *self.object*.
 
@@ -311,7 +313,7 @@ class CObjectDocumenter(Documenter):
         # should be safe to assume this is a list or None at this point.
         desired_members = self.options.members or []
 
-        object_members: List[Tuple[str, Any]] = []
+        object_members: List[Any] = []
         for member in desired_members:
             if member in self.object.children:
                 object_members.append((member, self.object.children[member]))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,19 +3,20 @@ Common pytest configuration for the test suites
 """
 
 import os
-import sys
 
 import pytest
+import sphinx
 
 from docutils.parsers.rst.states import RSTStateMachine, Struct, Inliner, state_classes
 from docutils.parsers.rst.languages import en
 from docutils.statemachine import StringList
 from docutils.utils import new_document
-from sphinx.testing.path import path
 from sphinx.util.docutils import sphinx_domains
 
-# SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
-# sys.path.append(os.path.join(SCRIPT_DIR, '..', 'src'))
+if sphinx.version_info < (7, 2):
+    from sphinx.testing.path import path as Path
+else:
+    from pathlib import Path
 
 pytest_plugins = "sphinx.testing.fixtures"
 
@@ -34,8 +35,8 @@ def local_app(make_app):
     # Provide sphinx with the path to the documentation directory.
     conf_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "assets"))
 
-    # Note the sphinx fixture expects a :class:`path` object, not a string
-    yield make_app(srcdir=path(conf_dir))
+    # Note the sphinx fixture expects a :class:`Path` object, not a string
+    yield make_app(srcdir=Path(conf_dir))
 
 
 @pytest.fixture()


### PR DESCRIPTION
Bump sphinx to 7.2.6.

Sphinx 7.2 dropped support for python 3.8. This project still supports 3.8. In order to work around this limitation the `[tool.poetry.group.dev.dependencies]` was expanded to use a [multiple constraint dependency](https://python-poetry.org/docs/dependency-specification/#multiple-constraints-dependencies)