### PR TITLE
Add support for Sphinx 8.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev-dependencies= [
     "types-docutils==0.20.0.20240310",
     "pylint==3.3.2",
     "furo>=2024.0.0",
+    "sphinx>=8.2 ; python_full_version >= '3.11'",
 ]
 
 [build-system]

--- a/src/sphinx_c_autodoc/__init__.py
+++ b/src/sphinx_c_autodoc/__init__.py
@@ -437,7 +437,8 @@ class CTypeDocumenter(CObjectDocumenter):
         """
         super().__init__(directive, name, indent)
 
-        # Sphinx 8.1 compatibility. Sphinx 8.2 moved most of the logic from `generate()` to `_generate()`
+        # Sphinx 8.1 compatibility. Sphinx 8.2 moved most of the logic from
+        # `generate()` to `_generate()`
         if sphinx.version_info < (8, 2):  # pragma: no cover
             self.generate = self._generate  # type: ignore
             self._super_generate = super().generate

--- a/src/sphinx_c_autodoc/__init__.py
+++ b/src/sphinx_c_autodoc/__init__.py
@@ -438,7 +438,7 @@ class CTypeDocumenter(CObjectDocumenter):
         super().__init__(directive, name, indent)
 
         # Sphinx 8.1 compatibility. Sphinx 8.2 moved most of the logic from `generate()` to `_generate()`
-        if sphinx.version_info < (8, 2):
+        if sphinx.version_info < (8, 2):  # pragma: no cover
             self.generate = self._generate  # type: ignore
             self._super_generate = super().generate
         else:

--- a/src/sphinx_c_autodoc/__init__.py
+++ b/src/sphinx_c_autodoc/__init__.py
@@ -19,10 +19,11 @@ import re
 from dataclasses import dataclass, field
 from itertools import groupby
 
-from typing import Any, List, Optional, Tuple, Dict
+from typing import Any, List, Optional, Tuple, Dict, cast
 
 from docutils.statemachine import ViewList, StringList
 from docutils import nodes
+import sphinx
 from sphinx.domains.c import CObject
 from sphinx.application import Sphinx
 from sphinx.util import logging
@@ -236,9 +237,11 @@ class CObjectDocumenter(Documenter):
         # TODO The :attr:`temp_data` is reset for each document ideally want to
         # use or make an attribute on `self.env` that is reset per run or just
         # not pickled.
-        modules_dict = self.env.temp_data.setdefault("c:loaded_modules", {})
+        modules_dict = cast(
+            Dict[str, Any], self.env.temp_data.setdefault("c:loaded_modules", {})
+        )
 
-        if filename not in modules_dict:
+        if filename not in modules_dict:  # type: ignore
             with open(filename, encoding="utf-8") as f:
                 contents = [f.read()]
 
@@ -434,35 +437,40 @@ class CTypeDocumenter(CObjectDocumenter):
         """
         super().__init__(directive, name, indent)
 
-        # Sphinx 3.1 compatibility. 4.0 deprecated the "reporter" attribute. 5.0
-        # removes it.
-        reporter = getattr(self.directive, "reporter", None)
+        # Sphinx 8.1 compatibility. Sphinx 8.2 moved most of the logic from `generate()` to `_generate()`
+        if sphinx.version_info < (8, 2):
+            self.generate = self._generate  # type: ignore
+            self._super_generate = super().generate
+        else:
+            self._super_generate = super()._generate
 
         self._original_directive = self.directive
         self.directive = DocumenterBridge(
             self.directive.env,
-            reporter,
+            None,
             self.directive.genopt,
             self.directive.lineno,
             self.directive.state,
         )
 
-    def generate(
+    def _generate(
         self,
         more_content: Optional[StringList] = None,
         real_modname: Optional[str] = None,
         check_module: bool = False,
         all_members: bool = False,
     ) -> None:
+        """Generate reST for the object given by *self.name*, and possibly for
+        its members.
+
+        If *more_content* is given, include that content. If *real_modname* is
+        given, use that module name to find attribute docs. If *check_module* is
+        True, only generate if the object is defined in the module name it is
+        imported from. If *all_members* is True, document all members.
         """
-        generate stuff
-        """
-        # The autodoc::Documenter is using the implied optional
-        # `real_modname: str = None` and mypy complains that this shouldn't be
-        # optional
-        super().generate(
+        self._super_generate(
             more_content=more_content,
-            real_modname=real_modname,  # type: ignore
+            real_modname=real_modname,
             check_module=check_module,
             all_members=all_members,
         )

--- a/uv.lock
+++ b/uv.lock
@@ -197,11 +197,11 @@ wheels = [
 
 [[package]]
 name = "clang"
-version = "17.0.6"
+version = "18.1.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/75/39/b56db712f3879d7e96ed5e747d9024308b0d8001df7daf60ad3fc8078aa9/clang-17.0.6.tar.gz", hash = "sha256:d228511e6a29e866dcbe99e10ed10649317b9b3e636ba805f6867b7afb6e8c44", size = 32167 }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/6d/202fe248475f92ab9057a4066d50fe8aaa2def62493894dc9a9814ce8d3b/clang-18.1.8.tar.gz", hash = "sha256:26d11859bab6da8d1fcdb85a244957f6c129a0cd15da2abca3059b054b87635f", size = 3101 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/c6/e5141f7780fe401c5749faa69b3dca5f4a19236528d544733585e291d13a/clang-17.0.6-py3-none-any.whl", hash = "sha256:d05ad6dddc9b360e94b9420e239c639a9117902cce8a57fd288a5226eea3092e", size = 32121 },
+    { url = "https://files.pythonhosted.org/packages/a5/3c/1bebce0b2588b913b48baea6eac5091c023f03cc0c8ab4b015a8315d0d09/clang-18.1.8-py3-none-any.whl", hash = "sha256:2f6a00126743ee23d8fcd2a2338b42ef4d29897f293ee3a1bc4d5925d8ee875c", size = 31627 },
 ]
 
 [[package]]
@@ -350,7 +350,7 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "pygments" },
     { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-basic-ng" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a0/e2/d351d69a9a9e4badb4a5be062c2d0e87bd9e6c23b5e57337fef14bef34c8/furo-2024.8.6.tar.gz", hash = "sha256:b63e4cee8abfc3136d3bc03a3d45a76a850bada4d6374d24c1716b0e01394a01", size = 1661506 }
@@ -719,6 +719,15 @@ wheels = [
 ]
 
 [[package]]
+name = "roman-numerals-py"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/76/48fd56d17c5bdbdf65609abbc67288728a98ed4c02919428d4f52d23b24b/roman_numerals_py-3.1.0.tar.gz", hash = "sha256:be4bf804f083a4ce001b5eb7e3c0862479d10f94c936f6c4e5f250aa5ff5bd2d", size = 9017 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/97/d2cbbaa10c9b826af0e10fdf836e1bf344d9f0abb873ebc34d1f49642d3f/roman_numerals_py-3.1.0-py3-none-any.whl", hash = "sha256:9da2ad2fb670bcf24e81070ceb3be72f6c11c440d73bd579fbeca1e9f330954c", size = 7742 },
+]
+
+[[package]]
 name = "snowballstemmer"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -770,7 +779,7 @@ wheels = [
 
 [[package]]
 name = "sphinx"
-version = "8.1.3"
+version = "8.2.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.11.*'",
@@ -786,6 +795,7 @@ dependencies = [
     { name = "packaging", marker = "python_full_version >= '3.11'" },
     { name = "pygments", marker = "python_full_version >= '3.11'" },
     { name = "requests", marker = "python_full_version >= '3.11'" },
+    { name = "roman-numerals-py", marker = "python_full_version >= '3.11'" },
     { name = "snowballstemmer", marker = "python_full_version >= '3.11'" },
     { name = "sphinxcontrib-applehelp", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinxcontrib-devhelp", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -794,9 +804,9 @@ dependencies = [
     { name = "sphinxcontrib-qthelp", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611 }
+sdist = { url = "https://files.pythonhosted.org/packages/38/ad/4360e50ed56cb483667b8e6dadf2d3fda62359593faabbe749a27c4eaca6/sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348", size = 8321876 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/60/1ddff83a56d33aaf6f10ec8ce84b4c007d9368b21008876fceda7e7381ef/sphinx-8.1.3-py3-none-any.whl", hash = "sha256:09719015511837b76bf6e03e42eb7595ac8c2e41eeb9c29c5b755c6b677992a2", size = 3487125 },
+    { url = "https://files.pythonhosted.org/packages/31/53/136e9eca6e0b9dc0e1962e2c908fbea2e5ac000c2a2fbd9a35797958c48b/sphinx-8.2.3-py3-none-any.whl", hash = "sha256:4405915165f13521d875a8c29c8970800a0141c14cc5416a38feca4ea5d9b9c3", size = 3589741 },
 ]
 
 [[package]]
@@ -805,7 +815,7 @@ version = "1.0.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/0b/a866924ded68efec7a1759587a4e478aec7559d8165fac8b2ad1c0e774d6/sphinx_basic_ng-1.0.0b2.tar.gz", hash = "sha256:9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9", size = 20736 }
 wheels = [
@@ -820,7 +830,7 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "clang" },
     { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
 [package.dev-dependencies]
@@ -832,6 +842,7 @@ dev = [
     { name = "pylint" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinxcontrib-autoprogram" },
     { name = "types-docutils" },
 ]
@@ -852,6 +863,7 @@ dev = [
     { name = "pylint", specifier = "==3.3.2" },
     { name = "pytest", specifier = "==8.3.4" },
     { name = "pytest-cov", specifier = "==6.0.0" },
+    { name = "sphinx", marker = "python_full_version >= '3.11'", specifier = ">=8.2" },
     { name = "sphinxcontrib-autoprogram", specifier = "==0.1.9" },
     { name = "types-docutils", specifier = "==0.20.0.20240310" },
 ]
@@ -887,7 +899,7 @@ version = "0.1.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c8/5f/044c87c306c9cbac68a4dccacb18ca0fdd4973096fdd92304ea069b11c59/sphinxcontrib-autoprogram-0.1.9.tar.gz", hash = "sha256:219655507fadca29b3062b5d86c37d94db48f03bde4b58d61526872bf72f57cc", size = 18843 }
 wheels = [


### PR DESCRIPTION
Sphinx 8.2 reworked some of the AutoDocument internals in particular it broke up the `generate()` method into `generate()` and `_generate()`.