### PR TITLE
Add support for Clang 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,14 @@ jobs:
         uses: actions/cache@v6
         with:
           path: llvm/lib/libclang.so*
-          key: llvm-20
+          key: llvm-21
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "20.1"
+          version: "21.1"
           cached: ${{ steps.cache-llvm.outputs.cache-hit }}
       - name: Symlink libclang.so
-        run: sudo ln -s ${{ env.LLVM_PATH }}/lib/libclang.so /usr/lib/x86_64-linux-gnu/libclang-20.so
+        run: sudo ln -s ${{ env.LLVM_PATH }}/lib/libclang.so /usr/lib/x86_64-linux-gnu/libclang-21.so
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -51,14 +51,14 @@ jobs:
         uses: actions/cache@v6
         with:
           path: llvm/lib/libclang.so*
-          key: llvm-20
+          key: llvm-21
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "20.1"
+          version: "21.1"
           cached: ${{ steps.cache-llvm.outputs.cache-hit }}
       - name: Symlink libclang.so
-        run: sudo ln -s ${{ env.LLVM_PATH }}/lib/libclang.so /usr/lib/x86_64-linux-gnu/libclang-20.so
+        run: sudo ln -s ${{ env.LLVM_PATH }}/lib/libclang.so /usr/lib/x86_64-linux-gnu/libclang-21.so
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -88,14 +88,14 @@ jobs:
         uses: actions/cache@v6
         with:
           path: llvm/lib/libclang.so*
-          key: llvm-20
+          key: llvm-21
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "20.1"
+          version: "21.1"
           cached: ${{ steps.cache-llvm.outputs.cache-hit }}
       - name: Symlink libclang.so
-        run: sudo ln -s ${{ env.LLVM_PATH }}/lib/libclang.so /usr/lib/x86_64-linux-gnu/libclang-20.so
+        run: sudo ln -s ${{ env.LLVM_PATH }}/lib/libclang.so /usr/lib/x86_64-linux-gnu/libclang-21.so
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -115,14 +115,14 @@ jobs:
         uses: actions/cache@v6
         with:
           path: llvm/lib/libclang.so*
-          key: llvm-20
+          key: llvm-21
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "20.1"
+          version: "21.1"
           cached: ${{ steps.cache-llvm.outputs.cache-hit }}
       - name: Symlink libclang.so
-        run: sudo ln -s ${{ env.LLVM_PATH }}/lib/libclang.so /usr/lib/x86_64-linux-gnu/libclang-20.so
+        run: sudo ln -s ${{ env.LLVM_PATH }}/lib/libclang.so /usr/lib/x86_64-linux-gnu/libclang-21.so
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/src/sphinx_c_autodoc/clang/comments.py
+++ b/src/sphinx_c_autodoc/clang/comments.py
@@ -5,9 +5,18 @@ Expose some CXComment functionality to python for libclang
 
 import ctypes
 
-from typing import Optional
+from typing import Any, Optional
 
 from clang import cindex
+
+
+# Access is necessary because clang does not expose a public CXString converter.
+# pylint: disable=protected-access
+def cxstring_to_str(value: Any) -> Optional[str]:
+    """Convert a CXString unless the clang bindings already converted it."""
+    if isinstance(value, cindex._CXString):
+        return cindex._CXString.from_result(value)
+    return value
 
 
 # pylint: disable=too-few-public-methods
@@ -22,4 +31,7 @@ class Comment(ctypes.Structure):
         """
         Return this comment as an xml string
         """
-        return cindex.conf.lib.clang_FullComment_getAsXML(self)
+        full_comment = cxstring_to_str(cindex.conf.lib.clang_FullComment_getAsXML(self))
+        # Clang 21 and up return empty string '', instead of None
+        # Keeping at callers logic to look for None until Clang 21 is min Clang version
+        return full_comment or None

--- a/src/sphinx_c_autodoc/clang/comments.py
+++ b/src/sphinx_c_autodoc/clang/comments.py
@@ -12,11 +12,8 @@ from clang import cindex
 
 # Access is necessary because clang does not expose a public CXString converter.
 # pylint: disable=protected-access
-def cxstring_to_str(value: Any) -> Optional[str]:
-    """Convert a CXString unless the clang bindings already converted it."""
-    if isinstance(value, cindex._CXString):
-        return cindex._CXString.from_result(value)
-    return value
+def cxstring_to_str(value: cindex._CXString) -> Optional[str]:
+    return cindex._CXString.from_result(value)
 
 
 # pylint: disable=too-few-public-methods

--- a/src/sphinx_c_autodoc/clang/comments.py
+++ b/src/sphinx_c_autodoc/clang/comments.py
@@ -12,8 +12,13 @@ from clang import cindex
 
 # Access is necessary because clang does not expose a public CXString converter.
 # pylint: disable=protected-access
-def cxstring_to_str(value: cindex._CXString) -> Optional[str]:
-    return cindex._CXString.from_result(value)
+def cxstring_to_str(value: Any) -> Optional[str]:
+    """Convert a CXString unless the clang bindings already converted it."""
+    # No cover because coverage uses clang 21, but clang 20 and earlier will
+    # excercise the branch
+    if isinstance(value, cindex._CXString):  # pragma: no cover
+        return cindex._CXString.from_result(value)
+    return value
 
 
 # pylint: disable=too-few-public-methods

--- a/src/sphinx_c_autodoc/clang/comments.py
+++ b/src/sphinx_c_autodoc/clang/comments.py
@@ -16,10 +16,9 @@ def cxstring_to_str(value: Any) -> Optional[str]:
     """Convert a CXString unless the clang bindings already converted it."""
     # No cover because coverage uses clang 21, but clang 20 and earlier will
     # exercise the else branch
-    if isinstance(value, cindex._CXString):  # pragma: no cover
-        return cindex._CXString.from_result(value)
-    else:  # pragma: no cover
-        return value  # pragma: no cover
+    if not isinstance(value, cindex._CXString):  # pragma: no cover
+        return value
+    return cindex._CXString.from_result(value)
 
 
 # pylint: disable=too-few-public-methods

--- a/src/sphinx_c_autodoc/clang/comments.py
+++ b/src/sphinx_c_autodoc/clang/comments.py
@@ -15,10 +15,11 @@ from clang import cindex
 def cxstring_to_str(value: Any) -> Optional[str]:
     """Convert a CXString unless the clang bindings already converted it."""
     # No cover because coverage uses clang 21, but clang 20 and earlier will
-    # excercise the branch
+    # exercise the else branch
     if isinstance(value, cindex._CXString):  # pragma: no cover
         return cindex._CXString.from_result(value)
-    return value
+    else:  # pragma: no cover
+        return value  # pragma: no cover
 
 
 # pylint: disable=too-few-public-methods

--- a/src/sphinx_c_autodoc/clang/patches.py
+++ b/src/sphinx_c_autodoc/clang/patches.py
@@ -175,7 +175,7 @@ def add_dll_entry_points() -> None:
     """
     cindex_list = getattr(cindex, "FUNCTION_LIST", None)
     # the function list was named `functionList` in clang 20 and before
-    if cindex_list is None: # pragma: no cover
+    if cindex_list is None:  # pragma: no cover
         # pylint: disable=no-member
         cindex_list = cindex.functionList
     # Create a sequence of all of the currently known function names in cindex.

--- a/src/sphinx_c_autodoc/clang/patches.py
+++ b/src/sphinx_c_autodoc/clang/patches.py
@@ -18,7 +18,7 @@ from typing import Optional, Tuple, List
 from clang import cindex
 from clang.cindex import Cursor, SourceLocation, SourceRange, TranslationUnit
 
-from sphinx_c_autodoc.clang.comments import Comment
+from sphinx_c_autodoc.clang.comments import Comment, cxstring_to_str
 
 
 def SourceLocation_isFromMainFile(self: SourceLocation) -> bool:
@@ -85,7 +85,9 @@ def Cursor_cached_raw_comment(self: Cursor) -> Optional[str]:
     it up each time it's called.
     """
     if self._raw_comment is None:
-        self._raw_comment = cindex.conf.lib.clang_Cursor_getRawCommentText(self)
+        self._raw_comment = cxstring_to_str(
+            cindex.conf.lib.clang_Cursor_getRawCommentText(self)
+        )
 
     return self._raw_comment
 
@@ -120,7 +122,6 @@ FUNCTION_LIST: List[Tuple] = [
         "clang_FullComment_getAsXML",
         [Comment],
         cindex._CXString,
-        cindex._CXString.from_result,
     ),
 ]
 
@@ -172,10 +173,15 @@ def add_dll_entry_points() -> None:
     Add functions available in the clang dll but not listed in the python
     clang bindings.
     """
+    cindex_list = getattr(cindex, "FUNCTION_LIST", None)
+    # the function list was named `functionList` in clang 20 and before
+    if cindex_list is None:
+        # pylint: disable=no-member
+        cindex_list = cindex.functionList
     # Create a sequence of all of the currently known function names in cindex.
-    known_names = tuple(f[0] for f in cindex.functionList)
+    known_names = tuple(f[0] for f in cindex_list)
 
     # Add any unknown versions in
     for func in FUNCTION_LIST:
         if func[0] not in known_names:
-            cindex.functionList.append(func)
+            cindex_list.append(func)

--- a/src/sphinx_c_autodoc/clang/patches.py
+++ b/src/sphinx_c_autodoc/clang/patches.py
@@ -175,7 +175,7 @@ def add_dll_entry_points() -> None:
     """
     cindex_list = getattr(cindex, "FUNCTION_LIST", None)
     # the function list was named `functionList` in clang 20 and before
-    if cindex_list is None:
+    if cindex_list is None: # pragma: no cover
         # pylint: disable=no-member
         cindex_list = cindex.functionList
     # Create a sequence of all of the currently known function names in cindex.

--- a/src/sphinx_c_autodoc/loader.py
+++ b/src/sphinx_c_autodoc/loader.py
@@ -1060,7 +1060,9 @@ def parse_comment(comment: Union[Token, PsuedoToken]) -> str:
     # Happens when there is no documentation comment in the source file for the
     # item.
     spelling = comment.spelling
-    if spelling is None:
+    # Spelling will come back as None in Clang 20 and before, in Clang 21
+    # and beyond it comes back as an empty string, ""
+    if spelling is None: # pragma: no cover
         return ""
 
     # Comments from clang start at the '/*' portion, but if the comment itself

--- a/src/sphinx_c_autodoc/loader.py
+++ b/src/sphinx_c_autodoc/loader.py
@@ -1062,7 +1062,7 @@ def parse_comment(comment: Union[Token, PsuedoToken]) -> str:
     spelling = comment.spelling
     # Spelling will come back as None in Clang 20 and before, in Clang 21
     # and beyond it comes back as an empty string, ""
-    if spelling is None: # pragma: no cover
+    if spelling is None:  # pragma: no cover
         return ""
 
     # Comments from clang start at the '/*' portion, but if the comment itself

--- a/src/sphinx_c_autodoc/loader.py
+++ b/src/sphinx_c_autodoc/loader.py
@@ -754,8 +754,17 @@ def object_from_cursor(cursor: Cursor) -> Optional[DocumentedObject]:
     anonymous_type = any(
         anon in cursor.type.spelling for anon in ("anonymous at", "unnamed at")
     )
+    anonymous_construct = (
+        cursor.kind
+        in (
+            cindex.CursorKind.STRUCT_DECL,
+            cindex.CursorKind.UNION_DECL,
+            cindex.CursorKind.ENUM_DECL,
+        )
+        and anonymous_type
+    )
 
-    if not name or anonymous_type:
+    if not name or anonymous_construct:
         # An anonymous construct which isn't contained in a typedef will have a
         # type spelling of:
         # "<construct> (anonymous at # <path_to_c_file>:<lineno>)"

--- a/tests/clang/test_patch_clang.py
+++ b/tests/clang/test_patch_clang.py
@@ -16,5 +16,8 @@ def test_re_patch():
     """
     patch_clang()
 
-    functions = tuple(f[0] for f in cindex.functionList)
+    cindex_function_list = getattr(cindex, "FUNCTION_LIST", None)
+    if cindex_function_list is None:
+        cindex_function_list = cindex.functionList
+    functions = tuple(f[0] for f in cindex_function_list)
     assert len(functions) == len(set(functions))

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-25T21:40:56.5602Z"
+exclude-newer = "2026-07-25T22:34:51.268064Z"
 exclude-newer-span = "P14D"
 
 [[package]]
@@ -245,11 +245,11 @@ wheels = [
 
 [[package]]
 name = "clang"
-version = "18.1.8"
+version = "21.1.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/6d/202fe248475f92ab9057a4066d50fe8aaa2def62493894dc9a9814ce8d3b/clang-18.1.8.tar.gz", hash = "sha256:26d11859bab6da8d1fcdb85a244957f6c129a0cd15da2abca3059b054b87635f", size = 3101, upload-time = "2025-02-17T21:49:01.037Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/9b/956a03195656847c4e3620dab9c36c9e53aecf685a6c3f0bc1ce025d7ec3/clang-21.1.7.tar.gz", hash = "sha256:01d5602b3fff77fef6d691a193d7aead4766b0f11d789d596200f3334a88f4b8", size = 8600, upload-time = "2025-12-18T22:04:51.886Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/3c/1bebce0b2588b913b48baea6eac5091c023f03cc0c8ab4b015a8315d0d09/clang-18.1.8-py3-none-any.whl", hash = "sha256:2f6a00126743ee23d8fcd2a2338b42ef4d29897f293ee3a1bc4d5925d8ee875c", size = 31627, upload-time = "2025-02-17T21:48:59.215Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a4/608c542925949b300a295baa422b568f835044c5e3ad20820676b840228a/clang-21.1.7-py3-none-any.whl", hash = "sha256:23ee8f7b62af648009aee5139516b2a2a9320680dbce6e42a53e48bd5e8983ea", size = 40240, upload-time = "2025-12-18T22:04:50.636Z" },
 ]
 
 [[package]]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility when reading Clang comments and converting comment data to text.
  - Added support for both current and legacy Clang function-list naming.
  - Prevented unrelated anonymous-type declarations from being treated as anonymous structs, unions, or enums.
  - Improved handling of empty comment results.
- **Tests**
  - Updated compatibility checks to validate function registration across supported Clang variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->