### PR TITLE
Bump to 1.7.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,16 @@ Change Log
 This document records all notable changes to `sphinx-c-autodoc <https://sphinx-c-autodoc.readthedocs.io/en/latest/>`_.
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
-`v1.6.1-dev`_ (unreleased)
+`v1.7.1-dev`_ (unreleased)
 ==========================
+
+`v1.7.0`_ (2026-08-08)
+==========================
+
+Added
+-----
+
+* Support for Clang 21
 
 `v1.6.0`_ (2025-11-15)
 ==========================
@@ -240,7 +248,8 @@ Fixes
 * Initial public release
 
 
-.. _v1.6.1-dev: https://github.com/speedyleion/sphinx-c-autodoc/compare/v1.5.0...main
+.. _v1.7.1-dev: https://github.com/speedyleion/sphinx-c-autodoc/compare/v1.7.0...main
+.. _v1.7.0: https://github.com/speedyleion/sphinx-c-autodoc/compare/v1.6.0...v1.7.0
 .. _v1.6.0: https://github.com/speedyleion/sphinx-c-autodoc/compare/v1.5.0...v1.6.0
 .. _v1.5.0: https://github.com/speedyleion/sphinx-c-autodoc/compare/v1.4.0...v1.5.0
 .. _v1.4.0: https://github.com/speedyleion/sphinx-c-autodoc/compare/v1.3.0...v1.4.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,13 +21,13 @@ sys.path.insert(0, SOURCE_DIR)
 # -- Project information -----------------------------------------------------
 
 project = u'Sphinx C Autodoc Extension'
-copyright = u'2019-2025, Nick'
+copyright = u'2019-2026, Nick'
 author = u'Nick'
 
 # The short X.Y version
-version = u'1.6'
+version = u'1.7'
 # The full version, including alpha/beta/rc tags
-release = u'1.6.0'
+release = u'1.7.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sphinx-c-autodoc"
-version = "1.6.0"
+version = "1.7.0"
 description = "A sphinx autodoc extension for c modules"
 authors = [
     {name="Nick"}

--- a/uv.lock
+++ b/uv.lock
@@ -1093,7 +1093,7 @@ wheels = [
 
 [[package]]
 name = "sphinx-c-autodoc"
-version = "1.6.0"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added unreleased `v1.7.1-dev` changelog entries and documented the `v1.7.0` release.
  * Updated documentation version information and copyright dates.
  * Added release notes for Clang 21 support.

* **Release Metadata**
  * Updated the project version to `1.7.0`.
  * Refreshed release comparison links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->