### PR TITLE
Use ruff for codestyle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        check: ["ruff-lint", "pycodestyle", "ruff-format", "mypy"]
+        check: ["ruff-lint", "ruff-format", "mypy"]
     steps:
       - uses: actions/checkout@v7
       - name: Cache LLVM and Clang

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ line-length = 88
 target-version = "py310"
 
 [tool.ruff.lint]
-select = ["B", "E4", "E7", "E9", "F", "I", "N", "PL", "RUF"]
+select = ["B", "E", "F", "I", "N", "PL", "RUF", "W"]
+ignore = ["E111", "E114", "E117", "W191"]
 
 [tool.ruff.lint.pylint]
 max-args = 10
@@ -44,7 +45,6 @@ max-args = 10
 [dependency-groups]
 dev = [
     "ruff==0.16.0",
-    "pycodestyle==2.14.0",
     "mypy==2.3.0",
     "pytest==9.1.1",
     "pytest-cov==7.1.0",

--- a/tox.ini
+++ b/tox.ini
@@ -11,13 +11,12 @@ mintoxversion = 4.0
 # e.g.: tox -e py39-cov
 # Note: the sphinx versions are spelled out so tox doesn't try to resolve them
 # as python versions
-envlist = py{310, 311, 312, 313, 314}{,-cov}, check-{ruff-lint,pycodestyle,ruff-format,mypy}, docs, sphinx-{four},
+envlist = py{310, 311, 312, 313, 314}{,-cov}, check-{ruff-lint,ruff-format,mypy}, docs, sphinx-{four},
 
 [testenv]
 runner = uv-venv-lock-runner
 commands =
     ruff-lint: uv run ruff check {toxinidir}/src/sphinx_c_autodoc {posargs}
-    pycodestyle: uv run pycodestyle {toxinidir}/src/sphinx_c_autodoc
     flake8: uv run flake8 {toxinidir}/src/sphinx_c_autodoc
     ruff-format: uv run ruff format --check {toxinidir}/src/sphinx_c_autodoc {toxinidir}/tests {posargs}
     mypy: uv run mypy {toxinidir}/src/sphinx_c_autodoc {posargs}
@@ -61,20 +60,6 @@ commands =
 
 [coverage]
 file = {toxinidir}/tests/.coveragerc
-
-[pycodestyle]
-# E203 conflicts with the Ruff formatter (whitespace before ':')
-# E402 is handled by Ruff (module-import-not-at-top-of-file)
-# E501 is handled by the Ruff formatter
-# E128 is handled by the Ruff formatter
-# W292 is handled by the Ruff formatter
-# W503 line break before binary operator, for whatever reason this and 504,
-#   line break after binary operator, are both enabled by default. These two
-#   can't happen at the same time so one has to die.
-ignore=E402,E501,E128,W292,W503,E203
-
-# No excludes, yet...
-; exclude=clang,glob3,heapq3
 
 [flake8]
 count = True

--- a/uv.lock
+++ b/uv.lock
@@ -713,15 +713,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pycodestyle"
-version = "2.14.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -979,7 +970,6 @@ dependencies = [
 dev = [
     { name = "furo" },
     { name = "mypy" },
-    { name = "pycodestyle" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -1002,7 +992,6 @@ requires-dist = [
 dev = [
     { name = "furo", specifier = ">=2024.0.0" },
     { name = "mypy", specifier = "==2.3.0" },
-    { name = "pycodestyle", specifier = "==2.14.0" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "ruff", specifier = "==0.16.0" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality checks to use Ruff’s broader style rules.
  * Removed the separate pycodestyle check and development dependency.
  * Simplified automated validation configuration while retaining linting, formatting, and type checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->